### PR TITLE
refactor: subscription の Accept エラー処理を cors_error に集約

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,20 +227,9 @@ async fn graphql(State(state): State<AppState>, req: AxumRequest<Body>) -> AxumR
 
     if operation_is_subscription(&gql_request) {
         if !is_accept_multipart_mixed(accept) {
-            let err = async_graphql::Response::from_errors(vec![async_graphql::ServerError::new(
+            return cors_error(
+                StatusCode::OK,
                 "サブスクリプションは Accept: multipart/mixed; boundary=\"graphql\"; subscriptionSpec=\"1.0\" が必要です",
-                None,
-            )]);
-            let json = match serde_json::to_vec(&err) {
-                Ok(json) => json,
-                Err(e) => return cors_error(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
-            };
-            return apply_cors(
-                AxumResponse::builder()
-                    .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(json))
-                    .unwrap(),
             );
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

受け入れ可能な `Accept` ヘッダーを持たない Subscription リクエストでは、`cors_error` と同じ手順（`Response::from_errors`、JSON シリアライズ、`apply_cors`）が重複していました。そのブロックを単一の `cors_error(StatusCode::OK, ...)` 呼び出しに置き換え、今後の `cors_error` への変更が一貫して適用されるようにしました。

## 確認

- `cargo test`
- `cargo fmt --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4754394c-92d7-49ca-97a7-f14c593a5e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4754394c-92d7-49ca-97a7-f14c593a5e7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hayatow/graphql-wasm/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
