### PR TITLE
fix(graphql): GET/HEAD で query のみ許可（mutation/subscription を拒否）

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,25 @@ fn operation_is_subscription(request: &GqlRequest) -> bool {
     }
 }
 
+/// GraphQL over HTTP: GET/HEAD は query のみ。mutation / subscription は CSRF 等のリスクのため拒否する。
+fn operation_allowed_on_get(request: &GqlRequest) -> bool {
+    let Ok(doc) = async_graphql_parser::parse_query(&request.query) else {
+        return true;
+    };
+    match &doc.operations {
+        DocumentOperations::Single(op) => op.node.ty == OperationType::Query,
+        DocumentOperations::Multiple(map) => {
+            let Some(name) = &request.operation_name else {
+                return false;
+            };
+            let key = Name::new(name);
+            map.get(&key)
+                .map(|op| op.node.ty == OperationType::Query)
+                .unwrap_or(false)
+        }
+    }
+}
+
 fn apply_cors<B>(mut res: AxumResponse<B>) -> AxumResponse<B> {
     res.headers_mut().insert(
         header::ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -230,6 +249,14 @@ async fn graphql(State(state): State<AppState>, req: AxumRequest<Body>) -> AxumR
         return cors_error(StatusCode::METHOD_NOT_ALLOWED, "GET, HEAD または POST のみ", is_head);
     };
 
+    if (method == Method::GET || is_head) && !operation_allowed_on_get(&gql_request) {
+        return cors_error(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "GET または HEAD では query 操作のみ許可されます。mutation と subscription は POST を使用してください。",
+            is_head,
+        );
+    }
+
     let schema = state.schema.clone();
 
     if operation_is_subscription(&gql_request) {
@@ -292,7 +319,7 @@ async fn playground() -> impl IntoResponse {
 <style>body{font-family:system-ui;margin:2rem;}textarea{width:100%;height:180px;}</style></head>
 <body>
 <h1>ToDo GraphQL (Workers)</h1>
-<p><code>POST /graphql</code> (JSON) または GET (query 文字列)。サブスクリプションは multipart Accept ヘッダが必要です。</p>
+<p><code>POST /graphql</code> (JSON) または GET（query 文字列・query のみ）。mutation / subscription は POST。サブスクリプションは multipart Accept ヘッダが必要です。</p>
 <textarea id="q">{"query":"query { todos { id title done } }"}</textarea><br/>
 <button id="run">実行</button>
 <pre id="out"></pre>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

GraphQL over HTTP の推奨に合わせ、`GET` / `HEAD` の `/graphql` では **query 操作のみ** を許可します。`mutation` と `subscription` は `405 Method Not Allowed` と JSON エラーで拒否し、リンクや `<img>` 経由の CSRF 様攻撃を防ぎます。

## 変更内容

- `operation_allowed_on_get` を追加し、パース済みドキュメントの実行対象操作が `Query` かどうかを判定
- 複数操作がある場合は `operationName` が必須（未指定は拒否）
- デモ用プレイグラウンドの説明文を更新

## テスト

- `cargo check` 済み
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b88c6090-4393-4a3c-9a72-7266731e0f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b88c6090-4393-4a3c-9a72-7266731e0f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hayatow/graphql-wasm/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
